### PR TITLE
chore: update recommended vscode extensions to new marketplace IDs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["johnsoncodehk.volar", "johnsoncodehk.vscode-typescript-vue-plugin"]
+  "recommendations": [
+    "vue.volar",
+    "vue.vscode-typescript-vue-plugin"
+  ]
 }


### PR DESCRIPTION
### Description
This PR updates the VSCode marketplace identifiers for the recommended editor extensions in this repo. The warning below should not show up again every time a dev opens up the repository in VSCode.

<img width="499" alt="have issues johnsoncodehk volar (not found in" src="https://user-images.githubusercontent.com/30433120/174236571-a9147b88-9fed-4e38-8509-f8581160bbeb.png">

### How to test
- `git fetch`
- `git checkout chore/update-recommended-extensions`
- `code .` (open up repo in VSCode)
- No `recommended extension not found` warning should be shown