### PR TITLE
Add profile view on asset send

### DIFF
--- a/src/components/ProfilePreviewComponent.vue
+++ b/src/components/ProfilePreviewComponent.vue
@@ -1,0 +1,97 @@
+<script>
+import _ from 'underscore';
+import ERC725js from '@erc725/erc725.js';
+import LSP3UniversalProfileMetaDataSchema from '@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json';
+import identicon from 'ethereum-blockies-base64';
+import { IPFS_GATEWAY_BASE_URL } from '../constants';
+import { isAddress } from 'web3-utils';
+
+export default {
+  data() {
+    return {
+      profileData: {
+        profileImage: {
+          url: '',
+        },
+      },
+      error: false,
+    };
+  },
+  props: {
+    account: String,
+  },
+  watch: {
+    account: async function updateProfile() {
+      this.updateProfile(this.account);
+    },
+  },
+
+  // Executed when the profile component is rendered
+  // Here we LOAD the recipient Universal Profile data
+  async mounted() {
+    this.updateProfile(this.account);
+  },
+
+  methods: {
+    async updateProfile(account) {
+      if (!isAddress(account)) {
+        this.profileData.description = 'Invalid Address';
+        this.profileData.profileImage.url = false;
+        this.profileData.identicon = false;
+        this.profileData.name = false;
+
+        return;
+      }
+
+      // generate identicon
+      this.profileData.identicon = identicon(account); // generates a "data:image/png;base64,..."
+
+      // INSTANTIATE erc725.js
+      // window.web3 was set in App.vue
+      const profile = new ERC725js(LSP3UniversalProfileMetaDataSchema, account, window.web3.currentProvider, {
+        ipfsGateway: IPFS_GATEWAY_BASE_URL,
+      });
+
+      let metaData;
+      try {
+        metaData = await profile.fetchData('LSP3Profile');
+      } catch (e) {
+        // IF it fails its likely NO Universal Profile, or a simple EOA (MetaMask)
+        this.profileData.name = false;
+        this.profileData.profileImage.url = false;
+        this.profileData.description = 'Address may not be a Universal Profile';
+      }
+
+      this.profileData = {
+        ...this.profileData,
+        ...metaData.value.LSP3Profile,
+      };
+
+      // GET the right image size for the profile image from the profile images array
+      this.profileData.profileImage = _.find(this.profileData.profileImage, (image) => {
+        if (image.width >= 200 && image.width <= 500) return image;
+      });
+
+      // If there is no image of the preferred size, take the default one
+      if (!this.profileData.profileImage && metaData.value.LSP3Profile.profileImage) {
+        this.profileData.profileImage = metaData.value.LSP3Profile.profileImage[0];
+      }
+      this.profileData.profileImage.url = this.profileData.profileImage.url.replace('ipfs://', profile.options.ipfsGateway);
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="center profile">
+    <div class="profileImage">
+      <div class="identicon" v-bind:style="{ backgroundImage: 'url(' + profileData.identicon + ')' }"></div>
+      <div class="image" v-bind:style="{ backgroundImage: 'url(' + profileData.profileImage?.url + ')' }"></div>
+    </div>
+
+    <span class="username" v-if="profileData.name"> @{{ profileData.name }} </span>
+    <p class="description" v-if="profileData.description">
+      {{ profileData.description }}
+    </p>
+  </div>
+</template>

--- a/src/components/SendModalComponent.vue
+++ b/src/components/SendModalComponent.vue
@@ -5,6 +5,7 @@ import { isAddress } from 'web3-utils';
 import { BLOCKCHAIN_EXPLORER_BASE_URL } from '../constants';
 
 import LSP7DigitalAsset from '@lukso/lsp-smart-contracts/artifacts/LSP7DigitalAsset.json';
+import ProfilePreviewComponent from './ProfilePreviewComponent.vue';
 
 const props = defineProps({
   assetAddress: String,
@@ -13,7 +14,7 @@ const props = defineProps({
 
 defineEmits(['close']);
 
-const assetRecipient = ref('0x064dDAfBD0D3bdEd05De350129d56F84864952bb');
+const assetRecipient = ref('');
 const amountToSend = ref(1);
 const isLoading = ref(false);
 const txHash = ref('');
@@ -80,7 +81,7 @@ async function sendAsset() {
           </fieldset>
         </form>
 
-        <!-- TODO: add UP profile image here when address is valid -->
+        <ProfilePreviewComponent v-if="assetRecipient" :account="assetRecipient" />
 
         <p v-if="isLoading">Sending asset...</p>
         <p v-if="txHash">


### PR DESCRIPTION
Adds profile view to asset send modal

I did not add an asset for invaid address image.

Closes #28 

<img width="787" alt="image" src="https://user-images.githubusercontent.com/54543428/174323300-241c434a-5518-446e-b8f0-ac58ae52ffd4.png">

<img width="785" alt="image" src="https://user-images.githubusercontent.com/54543428/174323340-dc1cda81-7be7-4729-bf37-6b1f64a53667.png">

<img width="790" alt="image" src="https://user-images.githubusercontent.com/54543428/174323378-46960356-e86d-479d-9569-824615a980b0.png">
