### PR TITLE
style: add rounded rectangle + remove box shadow for LSP7 tokens

### DIFF
--- a/src/components/CreationComponent.vue
+++ b/src/components/CreationComponent.vue
@@ -66,8 +66,8 @@ onMounted(async () => {
 
 <template>
   <div class="asset-wrapper">
-    <div class="preview-card" @click="$router.push(creationType === 'LSP8' ? `/collection/${address}/mint` : `/asset/${address}/mint`)">
-      <div class="image" :style="{ backgroundImage: `url(${iconUrl})` }">
+    <div class="preview-card" :style="{ boxShadow: creationType === 'LSP7' ? 'none' : '' }" @click="$router.push(creationType === 'LSP8' ? `/collection/${address}/mint` : `/asset/${address}/mint`)">
+      <div class="image" :style="{ backgroundImage: `url(${iconUrl})`, borderRadius: creationType === 'LSP7' ? '50%' : '' }">
         <small class="supply">{{ creationType }} - Supply: {{ totalSupply }}</small>
       </div>
 

--- a/src/components/OwnedCreationComponent.vue
+++ b/src/components/OwnedCreationComponent.vue
@@ -53,8 +53,8 @@ onMounted(async () => {
 
 <template>
   <div class="asset-wrapper">
-    <div class="preview-card" @click="showModal = !showModal">
-      <div class="image" :style="{ backgroundImage: `url(${iconUrl})` }">
+    <div class="preview-card" :style="{ boxShadow: isLsp7 ? 'none' : '' }" @click="showModal = !showModal">
+      <div class="image" :style="{ backgroundImage: `url(${iconUrl})`, borderRadius: isLsp7 ? '50%' : '' }">
         <small class="supply"> Balance: {{ balanceOf }} </small>
       </div>
 

--- a/src/styles.less
+++ b/src/styles.less
@@ -137,10 +137,10 @@ form {
 }
 
 .emptyLogo {
-    display: block;
-    margin: auto;
-    width: 150px;
-} 
+  display: block;
+  margin: auto;
+  width: 150px;
+}
 
 .asset-wrapper {
   text-align: center;
@@ -152,7 +152,7 @@ form {
   overflow: hidden;
   width: 200px;
 
-  height: 200px;
+  height: auto;
   text-align: center;
   margin: 0 auto;
   border-radius: 8px;
@@ -184,10 +184,10 @@ form {
     height: 165px;
     background-position: center;
     background-size: cover;
+    padding: 50%;
   }
 
   .infos {
     padding: 5px 10px 10px 10px;
   }
-
 }


### PR DESCRIPTION
Make the boxes to show up as rectangular for LSP7 Tokens + remove the box shadow in the background.
To clearly distinguish between tokens and NFTs in the portfolio.

![image](https://user-images.githubusercontent.com/31145285/174596975-0aad99f5-f9a9-4c4d-a9af-13a21af151ae.png).

Closes #59 
